### PR TITLE
[2026-02-20] Fix list indentation

### DIFF
--- a/_notes/Public/sleep-disorder-analysis.md
+++ b/_notes/Public/sleep-disorder-analysis.md
@@ -17,12 +17,12 @@ Stress has become a critical public health concern, yet its relationship with da
 
 The analysis was built on top of these key dependencies:
 
-- Build automation: GNU Make
-- Data modelling: pandas, scikit-learn
-- Data validation: Deepchecks, Pandera
-- Data visualization: Altair, Matplotlib, SciencePlots, Seaboarn
-- Dependency management: Conda, conda-lock, Docker
-- Reporting: Quarto, Jupyter
+    - Build automation: GNU Make
+    - Data modelling: pandas, scikit-learn
+    - Data validation: Deepchecks, Pandera
+    - Data visualization: Altair, Matplotlib, SciencePlots, Seaboarn
+    - Dependency management: Conda, conda-lock, Docker
+    - Reporting: Quarto, Jupyter
 
 Click [here](https://www.yhouyang.me/sleep-disorder-analysis/sleep-disorder-analysis.html) to view the research report.
 

--- a/_notes/Public/wordguess.md
+++ b/_notes/Public/wordguess.md
@@ -18,13 +18,14 @@ To install the package, run the following command:
     ```bash
     pip install -i https://test.pypi.org/simple/ wordguess
     ```
+
 The analysis was built on top of these key dependencies:
 
-- Continuous integration/development: GitHub Actions
-- Documentation: Quarto, quartodoc
-- Dependency management: Conda, Hatch
-- Python package template: Copier, pyOpenSci
-- Testing: Codecov, pytest
+    - Continuous integration/development: GitHub Actions
+    - Documentation: Quarto, quartodoc
+    - Dependency management: Conda, Hatch
+    - Python package template: Copier, pyOpenSci
+    - Testing: Codecov, pytest
 
 Click [here](https://ubc-mds.github.io/wordguess/) to view the package manual.
 


### PR DESCRIPTION
Normalize Markdown list formatting in _notes/Public files. Convert top-level hyphen lists to indented list items so they render correctly in sleep-disorder-analysis.md and wordguess.md, and add a missing blank line after the pip install code block in wordguess.md. No content changes beyond formatting.